### PR TITLE
Add index.theme

### DIFF
--- a/index.theme
+++ b/index.theme
@@ -1,0 +1,8 @@
+[X-GNOME-Metatheme]
+Name=Blackbird
+Type=X-GNOME-Metatheme
+Comment=Blackbird theme
+GtkTheme=Blackbird
+MetacityTheme=Blackbird
+IconTheme=Adwaita
+CursorTheme=Adwaita


### PR DESCRIPTION
As far as I know, MATE's theme chooser (`mate-appearance-properties`) is the only thing that uses this but it would be good to support it.

Why am I defaulting to adwaita-icon-theme and cursor theme? Because it's installed everywhere. Debian (and therefore Ubuntu)'s GTK3 depends on it. If we set a theme there that's not installed, users get an ugly warning message:

![numix-missing-icon-theme](https://cloud.githubusercontent.com/assets/876259/16136806/d7dc7a82-33fb-11e6-8c91-4b3501d46cad.png)