### PR TITLE
gtk2: Hyperlink color in Pidgin

### DIFF
--- a/gtk-2.0/gtkrc
+++ b/gtk-2.0/gtkrc
@@ -1,6 +1,6 @@
 # Evolve GTK Theme
 
-gtk_color_scheme = "base_color:#333333\nbg_color:#383838\ntooltip_bg_color:#333333\nselected_bg_color:#5588ee\ntext_color:#eeeeee\nfg_color:#dedede\ntooltip_fg_color:#dedede\nselected_fg_color:#f9f9f9\nmenubar_bg_color:#333333\nmenubar_fg_color:#dedede\ntoolbar_bg_color:#333333\ntoolbar_fg_color:#dedede\nmenu_bg_color:#333333\nmenu_fg_color:#dedede\npanel_bg_color:#333333\npanel_fg_color:#dedede\nlink_color:#5588ee"
+gtk_color_scheme = "base_color:#333333;bg_color:#383838;tooltip_bg_color:#333333;selected_bg_color:#5588ee;text_color:#eeeeee;fg_color:#dedede;tooltip_fg_color:#dedede;selected_fg_color:#f9f9f9;menubar_bg_color:#333333;menubar_fg_color:#dedede;toolbar_bg_color:#333333;toolbar_fg_color:#dedede;menu_bg_color:#333333;menu_fg_color:#dedede;panel_bg_color:#333333;panel_fg_color:#dedede;link_color:#5588ee"
 
 gtk-icon-sizes = "panel=16,16:gtk-button=16,16" # Icon sizes
 gtk-button-images = 0 # Disables icons in buttons

--- a/gtk-2.0/gtkrc
+++ b/gtk-2.0/gtkrc
@@ -1,6 +1,6 @@
 # Evolve GTK Theme
 
-gtk_color_scheme = "base_color:#333333;bg_color:#383838;tooltip_bg_color:#333333;selected_bg_color:#5588ee;text_color:#eeeeee;fg_color:#dedede;tooltip_fg_color:#dedede;selected_fg_color:#f9f9f9;menubar_bg_color:#333333;menubar_fg_color:#dedede;toolbar_bg_color:#333333;toolbar_fg_color:#dedede;menu_bg_color:#333333;menu_fg_color:#dedede;panel_bg_color:#333333;panel_fg_color:#dedede;link_color:#5588ee"
+gtk_color_scheme = "base_color:#333333;bg_color:#383838;tooltip_bg_color:#333333;selected_bg_color:#5588ee;text_color:#eeeeee;fg_color:#dedede;tooltip_fg_color:#dedede;selected_fg_color:#f9f9f9;menubar_bg_color:#333333;menubar_fg_color:#dedede;toolbar_bg_color:#333333;toolbar_fg_color:#dedede;menu_bg_color:#333333;menu_fg_color:#dedede;panel_bg_color:#333333;panel_fg_color:#dedede;link_color:#5588ee;visited_link_color:#7777ff;"
 
 gtk-icon-sizes = "panel=16,16:gtk-button=16,16" # Icon sizes
 gtk-button-images = 0 # Disables icons in buttons
@@ -86,7 +86,17 @@ style "evolve-default" {
 	WnckTasklist::fade-overlay-rect = 0
 
 	GtkWidget::link-color = @link_color
-	GtkWidget::visited-link-color = @text_color
+	GtkWidget::visited-link-color = @visited_link_color
+
+	GnomeHRef::link_color = @link_color
+
+	GtkHTML::link_color = @link_color
+	GtkHTML::alink_color = @link_color
+	GtkHTML::vlink_color = @visited_link_color
+
+	GtkIMHtml::hyperlink-color = @link_color
+	GtkIMHtml::hyperlink-visited-color = @visited_link_color
+	GtkIMHtml::hyperlink-prelight-color = shade(1.3, @link_color)
 
 	fg[NORMAL] = @fg_color
 	fg[PRELIGHT] = @fg_color

--- a/gtk-2.0/gtkrc
+++ b/gtk-2.0/gtkrc
@@ -148,6 +148,7 @@ style "evolve-default" {
 		sliderstyle = 0	# 0 = none, 1 = handles
 		stepperstyle = 0 # 0 = standard, 1 = integrated stepper handles
 		toolbarstyle = 1 # 0 = flat, 1 = glassy, 2 = gradient
+		textstyle = 0 # 0 = no text shadow, 1 = shadow at bottom, 2 = top, 3 = bottom right, 4 = top left
    }
 }
 
@@ -277,7 +278,6 @@ style "evolve-tooltips" = "evolve-wider" {
 	bg[SELECTED] = @bg_color
 
 	engine "murrine" {
-		textstyle = 0
 		roundness = 2
 		rgba = FALSE
 	}
@@ -351,7 +351,6 @@ style "evolve-menu-item" = "evolve-wider" {
 	fg[SELECTED]	= @selected_fg_color
 
 	engine "murrine" {
-		textstyle = 0
 		border_shades = { 1.4, 1.4 }
 	}
 }
@@ -570,7 +569,6 @@ widget_class "*XfsmLogoutDialog*" style "xfsm-logout"
 style "chromium-toolbar-button" {
 	engine "murrine" {
 		roundness = 2
-		textstyle = 0
 	}
 }
 
@@ -716,18 +714,3 @@ widget "*HandleBox*LPEToolToolbar*" style "inkscape-toolbar-fix"
 widget "*HandleBox*DropperToolbar*" style "inkscape-toolbar-fix"
 widget "*HandleBox*ConnectorToolbar*" style "inkscape-toolbar-fix"
 widget "*HandleBox*PaintbucketToolbar*" style "inkscape-toolbar-fix"
-
-# Performance Fixes
-
-style "performance-fix" {
-	engine "murrine" {
-		textstyle = 0
-	}
-}
-
-widget_class "*gtkmm__GtkWindow*" style "performance-fix" # Inkscape
-widget_class "*GimpDisplayShell*" style "performance-fix" # Gimp
-widget_class "*GimpToolbox*" style "performance-fix"
-widget_class "*GimpMenuDock*" style "performance-fix"
-widget "*OOoFixed*" style "performance-fix" # Openoffice/Libreoffice
-widget_class "*MozContainer*" style "performance-fix" # Firefox (Not sure if this one does anything though.)


### PR DESCRIPTION
The hyperlink in pidgin sessions weren't colored correctly. Led me all over the place until I finally got to compile some ancient version of gtkparasite which told me Pidgin uses [GtkIMHtml with own `hyperlink-color`](https://github.com/rosedu/Pidgin/blob/a88ae3d7c6a91ccb1e5182a0a67921e6856af97d/pidgin/gtkimhtml.c#L496-L508) and `hyperlink-visited-color` properties (which in all likelihood predate `GtkWidget.link-color`). Those properties were intended to be styled, but [were not so properly](https://github.com/shimmerproject/Blackbird/blob/911fe83775bd41f2c1cbd6787bb131331020420e/gtk-3.20/gtk-widgets.css#L7-L8) (Gtk2 vs Gtk3)?